### PR TITLE
Grammar fix in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 tktl2tiki2 LaTeX class
 ======================
 
-This is a thesis and course report LaTeX class following the conventions at the Computer Science Department of the University of Helsinki. The class is intended to used for the bachelor's thesis, master's thesis and various course and seminar reports.
+This is a thesis and course report LaTeX class following the conventions at the Computer Science Department of the University of Helsinki. The class is intended to be used for the bachelor's thesis, master's thesis and various course and seminar reports.
 
 The tktltiki2 class is appearance-wise largely based on the older tktltiki class, but nearly all features have been rewritten to make it less likely to break. Some of the features, most notably the automatic appendix page counting, are not included at least in the current version. The tktltiki-specifix bibtex style has been dropped in favour of babelbib package included in most recent LaTeX installations.
 


### PR DESCRIPTION
Trivial grammar fix in README.me: missing “be” in “to be used”.

GitHub also decided to add a trailing newline to the last line of the file. This is idiomatic, so I left it in the patch.
