### PR TITLE
\ccsdesc macro for ACM 2012 classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Documentation
 
 For now, refer to template-en.tex (English) or template-fi.tex (Finnish) to see how the class is used and what options are available. A more detailed documentation, along with full worked examples, will be published hopefully during January 2013.
 
+Requirements
+------------
+
+In order to use the templates with a [TeX Live](http://http://www.tug.org/texlive/) based environment, make sure that you have `texlive-latex-extra` package installed. This package is available at least on Ubuntu, Debian and MacPorts.
+
 
 Compiling with latexmk
 ----------------------

--- a/template-en.tex
+++ b/template-en.tex
@@ -74,8 +74,12 @@
 % The following can be used to specify keywords and classification of the paper:
 
 \keywords{keyword 1, keyword 2, keyword 3}
-\classification{} % classification according to ACM Computing Classification System (http://www.acm.org/about/class/)
-                  % This is probably mostly relevant for computer scientists
+% classification according to ACM Computing Classification System
+% See http://www.acm.org/about/class/ and http://dl.acm.org/ccs_flat.cfm
+% This is probably mostly relevant for computer scientists. Can be left empty.
+\classification{
+  \ccsdesc[300]{General and reference~Surveys and overviews}
+}
 
 % If the automatic page number counting is not working as desired in your case,
 % uncomment the following to manually set the number of pages displayed in the abstract page:

--- a/tktltiki2.cls
+++ b/tktltiki2.cls
@@ -3,6 +3,7 @@
 \RequirePackage{calc}
 \RequirePackage[pass]{geometry}[2010/09/12 v5.6 Page Geometry]
 \RequirePackage{babel}
+\RequirePackage{etoolbox}
 
 \newif\if@grading
 \newif\if@lastpagecounter
@@ -74,6 +75,16 @@
 \newcommand{\keywords}[1]{\renewcommand{\@keywords}{#1}}
 \renewcommand{\abstract}[1]{\renewcommand{\@abstract}{#1}}
 
+% command to support CCS 2012 LaTeX snippets from http://dl.acm.org/ccs_flat.cfm
+% low/100: normal text, medium/300: \textit, high/500: \textbf
+% example:
+% \classification{
+%    \ccsdesc[500]{Computer systems organization~n-tier architectures}
+%    \ccsdesc[300]{Information systems~Distributed storage}
+% }
+\newcommand{\ccsdesc}[2][300]{
+    \\ \ifnumless{#1}{300}{#2}{\ifnumless{#1}{500}{\textit{#2}}{\textbf{#2}}}
+}
 
 % -- Language-dependent strings --
 


### PR DESCRIPTION
To support LaTeX snippets from http://dl.acm.org/ccs_flat.cfm.

Quote from http://www.cs.helsinki.fi/opiskelu/pro-gradu-tutkielman-aloittaminen-0:

> HUOM! Luokitustapa on muuttunut 1.1.2013: Nyt laitoksen opinnäytteissä
> käytetään ACM Computing Classification System 2012 -versiota:
> valitse 1-3 käsitettä listasta siten, että ne kuvaavat työsi aluetta
> mahdollisimman tarkasti. Valitsemalla (klikkaamalla) käsitettä ACM:n
> CCS-puusta siitä generoituu tiivistelmään tuleva pari, esimerkiksi
> "Information systems --> Data encryption". Jos käsitteen relevanssi on
> tutkielmassasi korkea, se lihavoidaan; jos keskimääräinen, sekursivoidaan;
> ja jos matala, tekstityyppinä on normaali teksti.
